### PR TITLE
Remove module_variable_optional_attrs experiments and bump terraform min version to 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-## 0.2.0  (May 3, 2023)
+## 0.2.0  (May 4, 2023)
 
 IMPROVEMENTS/ENHANCEMENTS:
 
 * Remove module_variable_optional_attrs experiments and bump terraform minimum version to 1.3 (#1)
 
-## 0.1.0  (May 3, 2023)
+## 0.1.0  (May 4, 2023)
 
 FEATURES:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ If you would like to see support for other cloud service providers (e.g. Azure, 
 
 | Ecosystem | Version |
 |-----------|---------|
-<!-- | [terraform](https://www.terraform.io) | ">= 1.1.0, < 1.3.0" | -->
 | [terraform](https://www.terraform.io) | ">= 1.3.0" |
 
 ### Terraform Providers
@@ -81,7 +80,7 @@ export GOOGLE_CREDENTIALS='{ "type": "service_account", "project_id": "demo-sett
 ```hcl
 module "packetfabric" {
   source  = "packetfabric/cloud-router-module/connectivity"
-  version = "0.1.0"
+  version = "0.2.0"
   name    = "demo-standalone1"
   labels  = ["terraform", "dev"]
   # PacketFabric Cloud Router Connection to Google
@@ -105,7 +104,7 @@ module "packetfabric" {
 ```hcl
 module "packetfabric" {
   source  = "packetfabric/cloud-router-module/connectivity"
-  version = "0.1.0"
+  version = "0.2.0"
   name    = "demo-standalone2"
   labels  = ["terraform", "dev"]
   # PacketFabric Cloud Router
@@ -134,7 +133,7 @@ module "packetfabric" {
 ```hcl
 module "packetfabric" {
   source  = "packetfabric/cloud-router-module/connectivity"
-  version = "0.1.0"
+  version = "0.2.0"
   name    = "demo-redundant"
   labels  = ["terraform", "prod"]
   # PacketFabric Cloud Router

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ If you would like to see support for other cloud service providers (e.g. Azure, 
 
 | Ecosystem | Version |
 |-----------|---------|
-| [terraform](https://www.terraform.io) | ">= 1.1.0, < 1.3.0" |
-<!-- | [terraform](https://www.terraform.io) | ">= 1.3.0" | -->
+<!-- | [terraform](https://www.terraform.io) | ">= 1.1.0, < 1.3.0" | -->
+| [terraform](https://www.terraform.io) | ">= 1.3.0" |
 
 ### Terraform Providers
 

--- a/main.tf
+++ b/main.tf
@@ -13,9 +13,7 @@ terraform {
       version = ">= 4.61.0"
     }
   }
-  # required_version = ">= 1.3.0"
-  required_version = ">= 1.1.0, < 1.3.0"
-  experiments      = [module_variable_optional_attrs] # until consul-terraform-sync supports terraform v1.3+
+  required_version = ">= 1.3.0"
 }
 
 # PacketFabric Cloud Router


### PR DESCRIPTION

## Description

Remove `module_variable_optional_attrs` experiments and bump terraform min version to 1.3.

## Checklist

<!-- Update as needed -->

- [x] tested locally
- [x] added/updated docs
